### PR TITLE
Search endpoints km

### DIFF
--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -29,6 +29,18 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
     end
   end
 
+  def index
+    if params[:name]
+      item = Item.name_finder(params[:name])
+    end
+
+    if item
+      render json: serializer.new(item)
+    else
+      render json: {"data": []}, status: 200
+    end
+  end
+
   def serializer
     ItemSerializer
   end

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -2,20 +2,19 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
 
   def show
     if params[:name]
-      item = Item.where('lower(name) LIKE ?', "%#{params[:name].downcase}%")
-                 .order(:name)
-                 .first
+      item = Item.name_finder(params[:name]).first
     end
+
     if params[:max_price] && params[:min_price]
       item = Item.where('unit_price >= ? AND unit_price <=?', params[:min_price].to_f, params[:max_price])
                  .order(:name)
                  .first
     end
+
     if params[:min_price]
-      item = Item.where('unit_price >= ?', params[:min_price].to_f)
-                 .order(:name)
-                 .first
+      item = Item.min_price_finder(params[:min_price]).first
     end
+
     if params[:max_price]
       item = Item.where('unit_price <= ?', params[:max_price].to_f)
                  .order(:name)
@@ -33,6 +32,7 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
     if params[:name]
       item = Item.name_finder(params[:name])
     end
+    
     if params[:min_price]
       item = Item.min_price_finder(params[:min_price])
     end

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -24,6 +24,8 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
 
     if item
       render json: serializer.new(item)
+    else
+      render json: {"data": {}}, status: 200
     end
   end
 

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::Items::ItemSearcherController < ApplicationController
+
+  def show
+    if params[:name]
+      item = Item.where('lower(name) LIKE ?', "%#{params[:name].downcase}%")
+                 .order(:name)
+                 .first
+    end
+
+    render json: serializer.new(item)
+  end
+
+  def serializer
+    ItemSerializer
+  end
+
+end

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Items::ItemSearcherController < ApplicationController
   before_action :validate_name, only: [:show]
+  before_action :validate_price, only: [:show]
 
   def show
     if params[:name]

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -5,9 +5,15 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
       item = Item.where('lower(name) LIKE ?', "%#{params[:name].downcase}%")
                  .order(:name)
                  .first
+    else params[:min_price]
+      item = Item.where('unit_price >= ?', params[:min_price].to_i)
+                 .order(:name)
+                 .first
     end
 
-    render json: serializer.new(item)
+    if item
+      render json: serializer.new(item)
+    end
   end
 
   def serializer

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -33,6 +33,9 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
     if params[:name]
       item = Item.name_finder(params[:name])
     end
+    if params[:min_price]
+      item = Item.min_price_finder(params[:min_price])
+    end
 
     if item
       render json: serializer.new(item)

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -7,17 +7,17 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
                  .first
     end
     if params[:max_price] && params[:min_price]
-      item = Item.where('unit_price >= ? AND unit_price <=?', params[:min_price].to_i, params[:max_price])
+      item = Item.where('unit_price >= ? AND unit_price <=?', params[:min_price].to_f, params[:max_price])
                  .order(:name)
                  .first
     end
     if params[:min_price]
-      item = Item.where('unit_price >= ?', params[:min_price].to_i)
+      item = Item.where('unit_price >= ?', params[:min_price].to_f)
                  .order(:name)
                  .first
     end
     if params[:max_price]
-      item = Item.where('unit_price <= ?', params[:max_price].to_i)
+      item = Item.where('unit_price <= ?', params[:max_price].to_f)
                  .order(:name)
                  .first
     end

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::Items::ItemSearcherController < ApplicationController
+  before_action :validate_name, only: [:show]
 
   def show
     if params[:name]
@@ -32,7 +33,7 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
     if params[:name]
       item = Item.name_finder(params[:name])
     end
-    
+
     if params[:min_price]
       item = Item.min_price_finder(params[:min_price])
     end

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -5,8 +5,14 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
       item = Item.where('lower(name) LIKE ?', "%#{params[:name].downcase}%")
                  .order(:name)
                  .first
-    else params[:min_price]
+    end
+    if params[:min_price]
       item = Item.where('unit_price >= ?', params[:min_price].to_i)
+                 .order(:name)
+                 .first
+    end
+    if params[:max_price]
+      item = Item.where('unit_price <= ?', params[:max_price].to_i)
                  .order(:name)
                  .first
     end

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -5,19 +5,13 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
   def show
     if params[:name]
       item = Item.name_finder(params[:name]).first
-    end
-
-    if params[:max_price] && params[:min_price]
+    elsif params[:max_price] && params[:min_price]
       item = Item.where('unit_price >= ? AND unit_price <=?', params[:min_price].to_f, params[:max_price])
                  .order(:name)
                  .first
-    end
-
-    if params[:min_price]
+    elsif params[:min_price]
       item = Item.min_price_finder(params[:min_price]).first
-    end
-
-    if params[:max_price]
+    elsif params[:max_price]
       item = Item.where('unit_price <= ?', params[:max_price].to_f)
                  .order(:name)
                  .first
@@ -32,15 +26,13 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
 
   def index
     if params[:name]
-      item = Item.name_finder(params[:name])
+      items = Item.name_finder(params[:name])
+    elsif params[:min_price]
+      items = Item.min_price_finder(params[:min_price])
     end
 
-    if params[:min_price]
-      item = Item.min_price_finder(params[:min_price])
-    end
-
-    if item
-      render json: serializer.new(item)
+    if items
+      render json: serializer.new(items)
     else
       render json: {"data": []}, status: 200
     end

--- a/app/controllers/api/v1/items/item_searcher_controller.rb
+++ b/app/controllers/api/v1/items/item_searcher_controller.rb
@@ -6,6 +6,11 @@ class Api::V1::Items::ItemSearcherController < ApplicationController
                  .order(:name)
                  .first
     end
+    if params[:max_price] && params[:min_price]
+      item = Item.where('unit_price >= ? AND unit_price <=?', params[:min_price].to_i, params[:max_price])
+                 .order(:name)
+                 .first
+    end
     if params[:min_price]
       item = Item.where('unit_price >= ?', params[:min_price].to_i)
                  .order(:name)

--- a/app/controllers/api/v1/merchants/merchant_searcher_controller.rb
+++ b/app/controllers/api/v1/merchants/merchant_searcher_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::Merchants::MerchantSearcherController < ApplicationController
+
+  def show
+    if params[:name]
+      merchant = Merchant.name_finder(params[:name]).first
+    end
+
+    if merchant
+      render json: serializer.new(merchant)
+    else
+      render json: {"data": {}}, status: 200
+    end
+
+
+  end
+
+  def serializer
+    MerchantSerializer
+  end
+
+end

--- a/app/controllers/api/v1/merchants/merchant_searcher_controller.rb
+++ b/app/controllers/api/v1/merchants/merchant_searcher_controller.rb
@@ -10,8 +10,18 @@ class Api::V1::Merchants::MerchantSearcherController < ApplicationController
     else
       render json: {"data": {}}, status: 200
     end
+  end
 
+  def index
+    if params[:name]
+      merchants = Merchant.name_finder(params[:name])
+    end
 
+    if merchants
+      render json: serializer.new(merchants)
+    else
+      render json: {"data": []}, status: 200
+    end
   end
 
   def serializer

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::API
   include PageCleaner
+
+  def validate_name
+    if params.keys.sort == ["name", "min_price", "controller", "action"].sort ||
+      params.keys.sort == ["name", "max_price", "controller", "action"].sort ||
+      params.keys.sort == ["name", "max_price", "min_price", "controller", "action"].sort
+
+      render status: 400 and return
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,11 @@ class ApplicationController < ActionController::API
       render status: 400 and return
     end
   end
+
+  def validate_price
+    if params[:min_price].to_f < 0
+
+      render status: 400 and return
+    end
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,9 @@
 class Item < ApplicationRecord
   belongs_to :merchant
 
+  def self.name_finder(name)
+    where('lower(name) LIKE ?', "%#{name.downcase}%")
+    .order(:name)
+  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,10 @@ class Item < ApplicationRecord
     .order(:name)
   end
 
+  def self.min_price_finder(price)
+    where('unit_price >= ?', price.to_f)
+    .order(:name)
+  end
+
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,9 @@
 class Merchant < ApplicationRecord
   has_many :items
 
+  def self.name_finder(name)
+    where('lower(name) LIKE ?', "%#{name.downcase}%")
+    .order(:name)
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       end
       namespace :items do
         get '/:id/merchant', to: 'merchant#show'
+        get '/find', to: 'item_searcher#show'
       end
       
       resources :merchants, only: [:show, :index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :merchants do
         get '/:id/items', to: 'items#index'
+        get '/find', to: 'merchant_searcher#show'
       end
       namespace :items do
         get '/:id/merchant', to: 'merchant#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       namespace :items do
         get '/:id/merchant', to: 'merchant#show'
         get '/find', to: 'item_searcher#show'
+        get '/find_all', to: 'item_searcher#index'
       end
       
       resources :merchants, only: [:show, :index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       namespace :merchants do
         get '/:id/items', to: 'items#index'
         get '/find', to: 'merchant_searcher#show'
+        get '/find_all', to: 'merchant_searcher#index'
       end
       namespace :items do
         get '/:id/merchant', to: 'merchant#show'

--- a/spec/requests/api/v1/items/item_multi_search_spec.rb
+++ b/spec/requests/api/v1/items/item_multi_search_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'All Item search endpoint', type: :request do
+  let!(:item1) { create(:item, name: 'Turing Gear',
+                               unit_price: 20.00) }
+  let!(:item2) { create(:item, name: 'Widget',
+                               unit_price: 40.00) }
+  let!(:item3) { create(:item, name: 'Ring Thing',
+                               unit_price: 100.00) }
+  let!(:item4) { create(:item, name: 'Erin Gear',
+                               unit_price: 40.00) }
+  
+  describe 'returns Items using name query' do
+    context 'with valid params' do
+      let(:valid_name_param) { 'name=ring' }
+
+      subject { get '/api/v1/items/find_all', params: valid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'as a list in alphabtical order' do
+        subject
+        expect(json_data.class).to eq(Array)
+        expect(json_data.length).to eq(2)
+        expect(json_data.first[:id]).to eq(item3.id.to_s)
+        expect(json_data.last[:id]).to eq(item1.id.to_s)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_name_param) { 'name=NOMATCH' }
+
+      subject { get '/api/v1/items/find_all', params: invalid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a valid JSON formatted response' do
+        subject
+        expect(json_data.class).to eq(Array)
+        expect(json_data.length).to eq(0)
+      end
+    end
+  end
+
+end

--- a/spec/requests/api/v1/items/item_multi_search_spec.rb
+++ b/spec/requests/api/v1/items/item_multi_search_spec.rb
@@ -48,4 +48,25 @@ RSpec.describe 'All Item search endpoint', type: :request do
     end
   end
 
+  describe 'returns Items using min_price query' do
+    context 'with valid params' do
+      let(:valid_price_param) { 'min_price=40' }
+
+      subject { get '/api/v1/items/find_all', params: valid_price_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'as a list in alphabtical order' do
+        subject
+        expect(json_data.class).to eq(Array)
+        expect(json_data.length).to eq(3)
+        expect(json_data.first[:id]).to eq(item4.id.to_s)
+        expect(json_data.last[:id]).to eq(item2.id.to_s)
+      end
+    end
+  end
+
 end

--- a/spec/requests/api/v1/items/item_single_search_spec.rb
+++ b/spec/requests/api/v1/items/item_single_search_spec.rb
@@ -106,4 +106,35 @@ RSpec.describe 'Single Item search endpoint', type: :request do
     end
   end
 
+  describe 'returns an error for invalid query combos' do
+    subject { get '/api/v1/items/find', params: invalid_combo }
+    
+    context 'name & min_price' do
+      let(:invalid_combo)  { 'min_price=30&name=ring' }
+      
+      it 'has a 400 response' do
+        subject
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+    
+    context 'name & max_price' do
+      let(:invalid_combo)  { 'name=ring&max_price=30' }
+      
+      it 'has a 400 response' do
+        subject
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+    
+    context 'max_price & min_price & name' do
+      let(:invalid_combo)  { 'min_price=10&name=ring&max_price=30' }
+      
+      it 'has a 400 response' do
+        subject
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+
 end

--- a/spec/requests/api/v1/items/item_single_search_spec.rb
+++ b/spec/requests/api/v1/items/item_single_search_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Single Item search endpoint', type: :request do
+  describe 'returns Item using name query' do
+    let!(:item1) { create(:item, name: 'Turing Gear') }
+    let!(:item2) { create(:item, name: 'Widget') }
+    let!(:item3) { create(:item, name: 'Ring Thing') }
+    let!(:item4) { create(:item, name: 'Erin Gear') }
+
+    context 'with valid params' do
+      let(:valid_name_param) { 'name=ring'}
+
+      subject { get '/api/v1/items/find', params: valid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'is the first record in alphabtical order' do
+        subject
+        expect(json_data.class).to eq(Hash)
+        expect(json_data[:id]).to eq(item3.id.to_s)
+      end
+    end
+  end
+
+end

--- a/spec/requests/api/v1/items/item_single_search_spec.rb
+++ b/spec/requests/api/v1/items/item_single_search_spec.rb
@@ -27,6 +27,23 @@ RSpec.describe 'Single Item search endpoint', type: :request do
         expect(json_data[:id]).to eq(item3.id.to_s)
       end
     end
+
+    context 'with invalid params' do
+      let(:invalid_name_param) { 'name=NOMATCH' }
+
+      subject { get '/api/v1/items/find', params: invalid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a valid JSON formatted response' do
+        subject
+        expect(json_data.class).to eq(Hash)
+        expect(json_data.length).to eq(0)
+      end
+    end
   end
   
   describe 'returns Item using min_price query' do

--- a/spec/requests/api/v1/items/item_single_search_spec.rb
+++ b/spec/requests/api/v1/items/item_single_search_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe 'Single Item search endpoint', type: :request do
         expect(json_data[:attributes][:unit_price]).to eq(item4.unit_price)
       end
     end
+
+    context 'with invalid params' do
+      let(:invalid_price_param) { 'min_price=-5' }
+
+      it 'has a 400 response' do
+        get '/api/v1/items/find', params: invalid_price_param
+        
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
   end
   
   describe 'returns Item using max_price query' do

--- a/spec/requests/api/v1/items/item_single_search_spec.rb
+++ b/spec/requests/api/v1/items/item_single_search_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Single Item search endpoint', type: :request do
+  let!(:item1) { create(:item, name: 'Turing Gear',
+                               unit_price: 20.00) }
+  let!(:item2) { create(:item, name: 'Widget',
+                               unit_price: 40.00) }
+  let!(:item3) { create(:item, name: 'Ring Thing',
+                               unit_price: 100.00) }
+  let!(:item4) { create(:item, name: 'Erin Gear',
+                               unit_price: 40.00) }
+  
   describe 'returns Item using name query' do
-    let!(:item1) { create(:item, name: 'Turing Gear') }
-    let!(:item2) { create(:item, name: 'Widget') }
-    let!(:item3) { create(:item, name: 'Ring Thing') }
-    let!(:item4) { create(:item, name: 'Erin Gear') }
-
     context 'with valid params' do
       let(:valid_name_param) { 'name=ring'}
 
@@ -21,6 +25,26 @@ RSpec.describe 'Single Item search endpoint', type: :request do
         subject
         expect(json_data.class).to eq(Hash)
         expect(json_data[:id]).to eq(item3.id.to_s)
+      end
+    end
+  end
+  
+  describe 'returns Item using min_price query' do
+    context 'with valid params' do
+      let(:valid_price_param) { 'min_price=40'}
+
+      subject { get '/api/v1/items/find', params: valid_price_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'is the first record in alphabtical order' do
+        subject
+        expect(json_data.class).to eq(Hash)
+        expect(json_data[:id]).to eq(item4.id.to_s)
+        expect(json_data[:attributes][:unit_price]).to eq(item4.unit_price)
       end
     end
   end

--- a/spec/requests/api/v1/items/item_single_search_spec.rb
+++ b/spec/requests/api/v1/items/item_single_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Single Item search endpoint', type: :request do
   
   describe 'returns Item using name query' do
     context 'with valid params' do
-      let(:valid_name_param) { 'name=ring'}
+      let(:valid_name_param) { 'name=ring' }
 
       subject { get '/api/v1/items/find', params: valid_name_param}
 
@@ -31,7 +31,7 @@ RSpec.describe 'Single Item search endpoint', type: :request do
   
   describe 'returns Item using min_price query' do
     context 'with valid params' do
-      let(:valid_price_param) { 'min_price=40'}
+      let(:valid_price_param) { 'min_price=40' }
 
       subject { get '/api/v1/items/find', params: valid_price_param}
 
@@ -51,7 +51,7 @@ RSpec.describe 'Single Item search endpoint', type: :request do
   
   describe 'returns Item using max_price query' do
     context 'with valid params' do
-      let(:valid_price_param) { 'max_price=30'}
+      let(:valid_price_param) { 'max_price=30' }
 
       subject { get '/api/v1/items/find', params: valid_price_param}
 
@@ -65,6 +65,26 @@ RSpec.describe 'Single Item search endpoint', type: :request do
         expect(json_data.class).to eq(Hash)
         expect(json_data[:id]).to eq(item1.id.to_s)
         expect(json_data[:attributes][:unit_price]).to eq(item1.unit_price)
+      end
+    end
+  end
+  
+  describe 'returns Item using min_price and max_price query' do
+    context 'with valid params' do
+      let(:valid_price_param) { 'max_price=60&min_price=30' }
+
+      subject { get '/api/v1/items/find', params: valid_price_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'is the first record in alphabtical order' do
+        subject
+        expect(json_data.class).to eq(Hash)
+        expect(json_data[:id]).to eq(item4.id.to_s)
+        expect(json_data[:attributes][:unit_price]).to eq(item4.unit_price)
       end
     end
   end

--- a/spec/requests/api/v1/items/item_single_search_spec.rb
+++ b/spec/requests/api/v1/items/item_single_search_spec.rb
@@ -48,5 +48,25 @@ RSpec.describe 'Single Item search endpoint', type: :request do
       end
     end
   end
+  
+  describe 'returns Item using max_price query' do
+    context 'with valid params' do
+      let(:valid_price_param) { 'max_price=30'}
+
+      subject { get '/api/v1/items/find', params: valid_price_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'gets the record' do
+        subject
+        expect(json_data.class).to eq(Hash)
+        expect(json_data[:id]).to eq(item1.id.to_s)
+        expect(json_data[:attributes][:unit_price]).to eq(item1.unit_price)
+      end
+    end
+  end
 
 end

--- a/spec/requests/api/v1/merchants/merchant_multi_search_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_multi_search_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'Single Merchant search endpoint', type: :request do
+  let!(:merchant1) { create(:merchant, name: 'Turing Guy') }
+  let!(:merchant2) { create(:merchant, name: 'Widgette') }
+  let!(:merchant3) { create(:merchant, name: 'Bing Ring') }
+  let!(:merchant4) { create(:merchant, name: 'Erin Grey') }
+
+  describe 'returns Merchants using name query' do
+    context 'with valid params' do
+      let(:valid_name_param) { 'name=ring' }
+
+      subject { get '/api/v1/merchants/find_all', params: valid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'as a list in alphabtical order' do
+        subject
+        expect(json_data.class).to eq(Array)
+        expect(json_data.length).to eq(2)
+        expect(json_data.first[:id]).to eq(merchant3.id.to_s)
+        expect(json_data.last[:id]).to eq(merchant1.id.to_s)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_name_param) { 'name=NOMATCH' }
+
+      subject { get '/api/v1/merchants/find_all', params: invalid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a valid JSON formatted response' do
+        subject
+        expect(json_data.class).to eq(Array)
+        expect(json_data.length).to eq(0)
+      end
+    end
+  end
+
+end

--- a/spec/requests/api/v1/merchants/merchant_single_search_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_single_search_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Single Merchant search endpoint', type: :request do
+  let!(:merchant1) { create(:merchant, name: 'Turing Guy') }
+  let!(:merchant2) { create(:merchant, name: 'Widgette') }
+  let!(:merchant3) { create(:merchant, name: 'Bing Ring') }
+  let!(:merchant4) { create(:merchant, name: 'Erin Grey') }
+  
+  describe 'returns Item using name query' do
+    context 'with valid params' do
+      let(:valid_name_param) { 'name=ring' }
+
+      subject { get '/api/v1/merchants/find', params: valid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'is the first record in alphabtical order' do
+        subject
+        expect(json_data.class).to eq(Hash)
+        expect(json_data[:id]).to eq(merchant3.id.to_s)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_name_param) { 'name=NOMATCH' }
+
+      subject { get '/api/v1/merchants/find', params: invalid_name_param}
+
+      it 'has a successful 200 response' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a valid JSON formatted response' do
+        subject
+        expect(json_data.class).to eq(Hash)
+        expect(json_data.length).to eq(0)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Description
Creates endpoints to return single or multiple Items and Merchants with `find` and `find_all` by `name`, `min_price` and `max_price` query params. Partial string matches are possible with the `name` param.  Mostly happy path initial testing with some edge cases.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Attempted implementing feature to prohibit a negative number query for `min_price` Item search.  Passes spec locally, but fails Postman-provided testing.  Not sure the importance of this edge case to chase the error fro now.

## RSpec Results
```
Finished in 1.53 seconds (files took 4.65 seconds to load)
54 examples, 0 failures

Coverage report generated for RSpec to /Users/niv3kmcg/coding_projects/rails-engine/coverage. 516 / 519 LOC (99.42%) covered.
```